### PR TITLE
Update Circle CI tests to peek at .ssh directory.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,4 +17,5 @@ test:
 
   post:
     - bin/stop-webserver
+    - ls -al $HOME/.ssh
 


### PR DESCRIPTION
This is a test to determine how Circle CI handles unsafe PRs from forked projects outside the original organization.